### PR TITLE
erases ambiguity present in the deliverables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@
 
 Hint: How many degrees does the hour hand move in an hour? How many degrees does the minute hand move in an hour?
 Assume that **both** the hour and the minute hands move **every minute** by the appropriate amount.
+
+Note: For measuring these angles, start at the minute hand and measure clockwise to determine the angle. (ex: "3:15" == 7.5 degrees but "3:20" == 340 degrees) 

--- a/spec/angle_spec.rb
+++ b/spec/angle_spec.rb
@@ -1,6 +1,6 @@
 describe "#clock_angle(time)" do
   it 'returns the correct angle between the clock hands representing 9:00' do
-    expect(clock_angle("9:00")).to eq(90)
+    expect(clock_angle("9:00")).to eq(270)
   end
 
   it 'returns the correct angle between the clock hands representing 12:00' do
@@ -13,6 +13,10 @@ describe "#clock_angle(time)" do
 
   it 'returns the correct angle between the clock hands representing 3:15' do
     expect(clock_angle("3:15")).to eq(7.5)
+  end
+
+  it 'returns the correct angle between the clock hands representing 3:20' do
+    expect(clock_angle("3:20")).to eq(340)
   end
 
   it 'returns the correct angle between the clock hands representing 8:30' do


### PR DESCRIPTION
There was no mention of which hand the student should begin measuring from to determine the angle. I added those instructions in the README & added a spec to confirm that the student is following this rule.